### PR TITLE
Don't call init after getting a provider. Fix NPE when calling 'stop'

### DIFF
--- a/src/keymaster/core.clj
+++ b/src/keymaster/core.clj
@@ -29,12 +29,11 @@
 
 (defn stop [provider]
   "Resets keyboard shortcuts and stops a provider. Call make-provider again to register new shortcuts"
-  (-> provider
-      .reset
-      .stop))
+  (do (.reset provider)
+      (.stop provider)))
 
 (defn make-provider []
   "Gets and initiates a keymaster provider, returns partial function which can be used to register shortcuts"
   (let [provider (com.tulskiy.keymaster.common.Provider/getCurrentProvider true)]
-    (.init provider)
     provider))
+

--- a/src/keymaster/example.clj
+++ b/src/keymaster/example.clj
@@ -7,7 +7,7 @@
 
 (defn- main []
   (let [prov (km/make-provider)]
-    (println prov)
     (km/register prov "control shift 1" #(km/stop prov))
     (km/register prov "control shift 2" #(println "Hello"))
-    (loop []  (Thread/sleep 1000)  (println "hello") (recur))))
+    (loop [] (Thread/sleep 1000) (println "hello") (recur))))
+


### PR DESCRIPTION
Somehow this works fine on OS X, but on Ubuntu the program will crash immediately when triggering any hot keys. jkeymaster now calls init() automatically upon a call to getCurrentProvider(), so the init call in clojure is no longer necessary.

Additionally, provider.reset() does not return anything, so I don't believe you can use the -> operator the way you were in km/stop. I replaced it with "do".
